### PR TITLE
feat(config): add ability to override base url in config

### DIFF
--- a/internal/requests/base.go
+++ b/internal/requests/base.go
@@ -251,12 +251,5 @@ func (rb *Base) getURL() string {
 		return rb.APIBaseURL
 	}
 
-	switch rb.Profile.Environment.String() {
-	case "sandbox":
-		return "https://connect.squareupsandbox.com"
-	case "production":
-		return "https://connect.squareup.com"
-	default:
-		return ""
-	}
+	return rb.Profile.GetBaseURL()
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -25,6 +25,8 @@ type Profile struct {
 	AccessToken           string
 	SandboxAccessToken    string
 	ProductionAccessToken string
+	SandboxBaseUrl        string
+	ProductionBaseUrl     string
 	Environment           flags.EnvironmentFlag
 }
 
@@ -116,6 +118,23 @@ func (p *Profile) GetAccessToken() (string, error) {
 	}
 
 	return "", errors.New("Your Access Token has not been setup. Use `square init` to set your Access Key")
+}
+
+func (p *Profile) GetBaseURL() string {
+	switch p.Environment.String() {
+	case "sandbox":
+		if viper.IsSet(p.ProfileName + "." + "sandbox_base_url") {
+			return viper.GetString(p.ProfileName + "." + "sandbox_base_url")
+		}
+		return "https://connect.squareupsandbox.com"
+	case "production":
+		if viper.IsSet(p.ProfileName + "." + "production_base_url") {
+			return viper.GetString(p.ProfileName + "." + "production_base_url")
+		}
+		return "https://connect.squareup.com"
+	default:
+		return ""
+	}
 }
 
 // GetConfigField returns the configuration field for the specific profile


### PR DESCRIPTION
This PR adds support for overriding base urls for both production and
sandbox in your config via a production_base_url and sanbox_base_url
option

Related:
- https://github.com/nickrobinson/square-cli/issues/15